### PR TITLE
Updated fiat payment's methods

### DIFF
--- a/environments/environments.go
+++ b/environments/environments.go
@@ -1,4 +1,4 @@
-package envs
+package environments
 
 const (
 	Sandbox    = "https://sandbox-api.limepay.io/v1"

--- a/http/requester.go
+++ b/http/requester.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 	"strings"
 
 	"github.com/LimePay/go-sdk/errors"
@@ -65,10 +66,19 @@ func (r *BaseRequester) ExecuteRequest(method string, route string, data interfa
 		return &sdkErr
 	}
 
-	err = json.Unmarshal(bytes, &model)
+	if model == nil {
+		return nil
+	}
 
-	if err != nil {
-		return err
+	switch reflect.TypeOf(model).String() {
+	case "*string":
+		*(model.(*string)) = string(bytes)
+	default:
+		err = json.Unmarshal(bytes, model)
+
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/payments/fiat/fiatpayments.go
+++ b/payments/fiat/fiatpayments.go
@@ -25,9 +25,9 @@ type internalPaymentsClient interface {
 type FiatPaymentsClient interface {
 	payments.RichPaymentsClient
 
-	GetInvoice(paymentID string) (*types.Invoice, error)
-	SendInvoice(paymentID string) (*types.Invoice, error)
-	GetReceipt(paymentID string) (*types.Receipt, error)
+	GetInvoice(paymentID string) (string, error)
+	SendInvoice(paymentID string) error
+	GetReceipt(paymentID string) (string, error)
 }
 
 // BaseFiatPaymentsClient -
@@ -84,34 +84,32 @@ func (f *BaseFiatPaymentsClient) computeAuthorizationSignature(signatureMetadata
 }
 
 // GetInvoice -
-func (f *BaseFiatPaymentsClient) GetInvoice(paymentID string) (*types.Invoice, error) {
+func (f *BaseFiatPaymentsClient) GetInvoice(paymentID string) (string, error) {
 	route := fmt.Sprintf(consts.RouteGetInvoice, paymentID)
 
-	invoice := &types.Invoice{}
+	invoice := ""
 
-	err := f.ExecuteRequest(consts.HTTPGet, route, nil, invoice)
+	err := f.ExecuteRequest(consts.HTTPGet, route, nil, &invoice)
 
 	return invoice, err
 }
 
 // SendInvoice -
-func (f *BaseFiatPaymentsClient) SendInvoice(paymentID string) (*types.Invoice, error) {
+func (f *BaseFiatPaymentsClient) SendInvoice(paymentID string) error {
 	route := fmt.Sprintf(consts.RouteSendInvoice, paymentID)
 
-	invoice := &types.Invoice{}
+	err := f.ExecuteRequest(consts.HTTPGet, route, nil, nil)
 
-	err := f.ExecuteRequest(consts.HTTPGet, route, nil, invoice)
-
-	return invoice, err
+	return err
 }
 
 // GetReceipt -
-func (f *BaseFiatPaymentsClient) GetReceipt(paymentID string) (*types.Receipt, error) {
+func (f *BaseFiatPaymentsClient) GetReceipt(paymentID string) (string, error) {
 	route := fmt.Sprintf(consts.RouteGetReceipt, paymentID)
 
-	receipt := &types.Receipt{}
+	receipt := ""
 
-	err := f.ExecuteRequest(consts.HTTPGet, route, nil, receipt)
+	err := f.ExecuteRequest(consts.HTTPGet, route, nil, &receipt)
 
 	return receipt, err
 }

--- a/payments/fiat/fiatpayments_test.go
+++ b/payments/fiat/fiatpayments_test.go
@@ -57,15 +57,9 @@ var fiatPaymentWithoutWeiAmountMock = types.Payment{
 	Type:                "FIAT_PAYMENT",
 }
 
-var invoiceMock = types.Invoice{
-	Subject:        "sample invoice subject",
-	BodyHeaderText: "sample invoice header text",
-}
+var invoiceMock = "sample invoice content"
 
-var receiptMock = types.Invoice{
-	Subject:        "sample receipt subject",
-	BodyHeaderText: "sample receipt header text",
-}
+var receiptMock = "sample receipt content"
 
 var privateKeyMock = "d723d3cdf932464de15845c0719ca13ce15e64c83625d86ddbfc217bd2ac5f5a"
 
@@ -163,8 +157,7 @@ func TestGetInvoice(t *testing.T) {
 
 	res, err := fiatPaymentsClient.GetInvoice(fiatPaymentMock.ID)
 
-	et.Assert(invoiceMock.Subject == res.Subject, "Invoice subject does not match")
-	et.Assert(invoiceMock.BodyHeaderText == res.BodyHeaderText, "Invoice body header text does not match")
+	et.Assert(invoiceMock == res, "Invoice content does not match")
 	et.Assert(err == nil, "Not expected error expected")
 }
 
@@ -175,15 +168,12 @@ func TestSendInvoice(t *testing.T) {
 
 	gock.New(test.Env).
 		Get("/payments/0/invoice").
-		Reply(200).
-		JSON(invoiceMock)
+		Reply(200)
 
 	fiatPaymentsClient := NewClient(http.NewRequester(test.Env, test.APIKey, test.APISecret))
 
-	res, err := fiatPaymentsClient.SendInvoice(fiatPaymentMock.ID)
+	err := fiatPaymentsClient.SendInvoice(fiatPaymentMock.ID)
 
-	et.Assert(invoiceMock.Subject == res.Subject, "Invoice subject does not match")
-	et.Assert(invoiceMock.BodyHeaderText == res.BodyHeaderText, "Invoice body header text does not match")
 	et.Assert(err == nil, "Not expected error expected")
 }
 
@@ -201,7 +191,6 @@ func TestGetReceipt(t *testing.T) {
 
 	res, err := fiatPaymentsClient.GetReceipt(fiatPaymentMock.ID)
 
-	et.Assert(receiptMock.Subject == res.Subject, "Receipt subject does not match")
-	et.Assert(receiptMock.BodyHeaderText == res.BodyHeaderText, "Receipt body header text does not match")
+	et.Assert(receiptMock == res, "Receipt content does not match")
 	et.Assert(err == nil, "Not expected error expected")
 }


### PR DESCRIPTION
Updated are the following methods:

 * GetInvoice(paymentID string) (string, error)
 * SendInvoice(paymentID string) error
 * GetReceipt(paymentID string) (string, error)